### PR TITLE
fix: avoid dependabot pr's for breaking bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      # manage manually any breaking change
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
# Pull Request

- [x] I have run `npm test` locally and all tests are passing.

## PR Description

Configure github actions to avoid dependabot making automatic pr's for breaking changes.
