### PR TITLE
feat(core): add support for promises to tap decorator

### DIFF
--- a/packages/bautajs-core/src/decorators/__tests__/tap.test.ts
+++ b/packages/bautajs-core/src/decorators/__tests__/tap.test.ts
@@ -15,4 +15,45 @@ describe('tap decorator', () => {
 
     expect(log).toHaveBeenCalledWith('star wars');
   });
+
+  test('should perform asynchronously the current step action but return the previous step value', async () => {
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    const log = jest.fn();
+    const tappedPromise = async (name: string) => {
+      await delay(100);
+      return log(name);
+    };
+    const getMovie = step(() => ({ name: 'star wars' }));
+
+    const pipeline = pipe(
+      getMovie,
+      tap(step<{ name: string }, { name: string }>(async ({ name }) => tappedPromise(name)))
+    );
+
+    await expect(pipeline({}, createContext({}), {} as BautaJSInstance)).resolves.toStrictEqual({
+      name: 'star wars'
+    });
+
+    expect(log).toHaveBeenCalledWith('star wars');
+  });
+
+  test('should ignore the error inside tap and return the previous step value', async () => {
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+    const tappedPromise = async (name: string) => {
+      await delay(100);
+
+      return Promise.reject(new Error(`We have an error: ${name}`));
+    };
+    const getMovie = step(() => ({ name: 'star wars' }));
+
+    const pipeline = pipe(
+      getMovie,
+      tap(step<{ name: string }, { name: string }>(async ({ name }) => tappedPromise(name)))
+    );
+
+    await expect(pipeline({}, createContext({}), {} as BautaJSInstance)).resolves.toStrictEqual({
+      name: 'star wars'
+    });
+  });
 });

--- a/packages/bautajs-core/src/decorators/tap.ts
+++ b/packages/bautajs-core/src/decorators/tap.ts
@@ -1,7 +1,12 @@
 import { Pipeline } from '../types';
+import { isPromise } from '../utils/is-promise';
+
 /**
  * Decorator that allows to transparently perform actions or side-effects,
  * such as logging and return the previous step result.
+ *
+ * Tap supports promises, but it will ignore any error thrown inside the tapped
+ * promise and will wait for its execution just to ignore its value.
  *
  * @param {Pipeline.StepFunction<TIn, any>} stepFn - The step fn to execute
  * @returns {Pipeline.StepFunction<TIn, TIn>}
@@ -27,8 +32,11 @@ import { Pipeline } from '../types';
  */
 export function tap<TIn>(stepFn: Pipeline.StepFunction<TIn, TIn>): Pipeline.StepFunction<TIn, TIn> {
   return (prev, ctx, bautajs) => {
-    stepFn(prev, ctx, bautajs);
+    const result = stepFn(prev, ctx, bautajs);
 
+    if (isPromise(result)) {
+      return (result as Promise<typeof result>).then(() => prev).catch(() => prev);
+    }
     return prev;
   };
 }

--- a/packages/bautajs-core/src/decorators/tap.ts
+++ b/packages/bautajs-core/src/decorators/tap.ts
@@ -20,12 +20,16 @@ import { isPromise } from '../utils/is-promise';
  *  const pipeline = pipe(
  *    randomPreviousPipeline,
  *    tap((prev) => {
- *      console.log(`some intermediate step. Prev is ${prev}`);
- *      // => 'some intermediate step. Prev is I am so random!'
+ *      console.log(`some intermediate step. Prev is "${prev}""`);
+ *      // prints 'some intermediate step. Prev is "I am so random!"'
+ *    }),
+ *    tap(async (prev) => {
+ *      await asyncProcess();
+ *      //'whether asyncProcess resolves or rejects. Prev still will be "I am so random!"'
  *    }),
  *    (prev) => {
  *      console.log(prev);
- *      // print 'I am so random!'
+ *      // prints 'I am so random!'
  *    }
  *  );
  *


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] I have added/updated documentation for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

This PR solves issue #27.

- Modified the tap decorator implementation using as base the pairwise decorator to allow async steps inside it.
- Since tap ignores completely any side effect from its input parameter, in case that this is a promise and that it is rejected, this condition is ignored and the previous step result is returned anyways.