### PR TITLE
fix(core): allow steps without return inside tap

### DIFF
--- a/packages/bautajs-core/src/decorators/__tests__/tap.test.ts
+++ b/packages/bautajs-core/src/decorators/__tests__/tap.test.ts
@@ -16,6 +16,22 @@ describe('tap decorator', () => {
     expect(log).toHaveBeenCalledWith('star wars');
   });
 
+  test('should work if the step in the tap does not return anything', async () => {
+    const log = jest.fn();
+    const getMovie = step(() => ({ name: 'star wars' }));
+    const logMovieName = step<{ name: string }, void>(({ name }) => {
+      log(name);
+    });
+
+    const pipeline = pipe(getMovie, tap(logMovieName));
+
+    expect(pipeline({}, createContext({}), {} as BautaJSInstance)).toStrictEqual({
+      name: 'star wars'
+    });
+
+    expect(log).toHaveBeenCalledWith('star wars');
+  });
+
   test('should perform asynchronously the current step action but return the previous step value', async () => {
     const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
     const log = jest.fn();

--- a/packages/bautajs-core/src/decorators/tap.ts
+++ b/packages/bautajs-core/src/decorators/tap.ts
@@ -8,6 +8,9 @@ import { isPromise } from '../utils/is-promise';
  * Tap supports promises, but it will ignore any error thrown inside the tapped
  * promise and will wait for its execution just to ignore its value.
  *
+ * The step inside tap does not need to return anything, since if it returns anything,
+ * it will be ignored anyways in favour of what was in the previous step.
+ *
  * @param {Pipeline.StepFunction<TIn, any>} stepFn - The step fn to execute
  * @returns {Pipeline.StepFunction<TIn, TIn>}
  *
@@ -34,7 +37,9 @@ import { isPromise } from '../utils/is-promise';
  *  );
  *
  */
-export function tap<TIn>(stepFn: Pipeline.StepFunction<TIn, TIn>): Pipeline.StepFunction<TIn, TIn> {
+export function tap<TIn>(
+  stepFn: Pipeline.StepFunction<TIn, TIn | void>
+): Pipeline.StepFunction<TIn, TIn | void> {
   return (prev, ctx, bautajs) => {
     const result = stepFn(prev, ctx, bautajs);
 


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] I have added/updated documentation for any new behavior.

## PR Description

With this change typescript will not complain if the step function inside the tap does not return anything, which is good since the goal of the tap decorator is ignore its result in favor of the result of the previous step function.
