### PR TITLE
fix(bautajs-fastify): remove dependency from fastify-x-request-id

### DIFF
--- a/packages/bautajs-fastify/README.md
+++ b/packages/bautajs-fastify/README.md
@@ -70,7 +70,6 @@ Licensed under the (MIT / Apache 2.0) License.
  - [fastify@4.5.3](https://github.com/fastify/fastify) - MIT
  - [@fastify/swagger@7.4.1](https://github.com/fastify/fastify-swagger) - MIT
  - [fastify-plugin@4.2.1](https://github.com/fastify/fastify-plugin) - MIT
- - [fastify-x-request-id@2.0.0](https://github.com/dimonnwc3/fastify-x-request-id) - MIT
  - [route-order@0.1.0](https://github.com/sfrdmn/node-route-order) - MIT
 
 ### Development

--- a/packages/bautajs-fastify/package.json
+++ b/packages/bautajs-fastify/package.json
@@ -29,8 +29,7 @@
     "@axa/bautajs-core": "^2.0.0-alpha.0",
     "@fastify/swagger": "^7.4.1",
     "fastify": "^4.5.3",
-    "fastify-plugin": "^4.2.1",
-    "fastify-x-request-id": "^2.0.0",
+    "fastify-plugin": "^4.2.1",    
     "route-order": "^0.1.0"
   },
   "devDependencies": {

--- a/packages/bautajs-fastify/src/index.ts
+++ b/packages/bautajs-fastify/src/index.ts
@@ -1,7 +1,8 @@
 import fp from 'fastify-plugin';
 import { FastifyInstance } from 'fastify';
-import responseXRequestId from 'fastify-x-request-id';
 import * as bautaJS from '@axa/bautajs-core';
+
+import responseXRequestId from './x-request-id-plugin';
 import explorerPlugin from './explorer';
 import exposeRoutesPlugin from './expose-routes';
 import { BautaJSFastifyPluginOptions } from './types';
@@ -47,7 +48,7 @@ export async function bautajsFastify(fastify: FastifyInstance, opts: any) {
 
   await fastify
     .register(
-      async function registerEndpoints(fastifySwagger) {
+      async function registerEndpoints(fastifySwagger: any) {
         // Scope of api prefix
         if (apiDefinition && (!opts.explorer || opts.explorer.enabled)) {
           fastifySwagger.register(explorerPlugin, {
@@ -81,6 +82,7 @@ export async function bautajsFastify(fastify: FastifyInstance, opts: any) {
 
 export * from './types';
 export * from './operators';
+
 export default fp(bautajsFastify, {
   fastify: '4.x',
   name: 'bautajs'

--- a/packages/bautajs-fastify/src/x-request-id-plugin.ts
+++ b/packages/bautajs-fastify/src/x-request-id-plugin.ts
@@ -1,0 +1,13 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import fp from 'fastify-plugin';
+
+async function xRequestId(fastify: FastifyInstance) {
+  fastify.addHook('onSend', async (req: FastifyRequest, reply: FastifyReply) => {
+    reply.header('x-request-id', req.id);
+  });
+}
+
+export default fp(xRequestId, {
+  fastify: '4.x',
+  name: 'bautajs-x-request-id'
+});


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.

## PR Description

- We remove the dependency to library fastify-x-request-id because it is fixing its dependency on fastify-plugin 3.x. Similar code is implemented in a plugin without external dependencies.

Related to #17 


![](https://media.giphy.com/media/S86GwKJRCiM3hPLd7N/giphy.gif)