### PR TITLE
fix(bautajs-fastify-example): add example server in fastify

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ Bauta.js is written using TypesScript. Shipped with the typings definitions to i
 ## Guides
 
 - [Hello World! API implementation step by step](./docs/guides/hello-world.md) using Bauta.js with Express.js.
-- Example of Express.js Bauta.js API project: [bautajs-example](./packages/bautajs-example).
+- Example of bauta.js API project using [express](https://github.com/expressjs/express): [bautajs-express-example](./packages/bautajs-express-example).
+- Example of bauta.js API project using [fastify](https://github.com/fastify/fastify): [bautajs-fastify-example](./packages/bautajs-fastify-example).
 - [How to unit test your code that use Bauta.js?](./docs/guides/testing.md)
 
 ## Benchmark

--- a/packages/bautajs-fastify-example/CHANGELOG.md
+++ b/packages/bautajs-fastify-example/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+> :warning: This CHANGELOG.md file is decommissioned and not maintained anymore. For checking the release notes of Bauta.js, please see the [Bauta.js releases page](https://github.com/axa-group/bauta.js/releases).
+
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+~~All notable changes to this project will be documented in this file.~~
+
+#### 1.0.0 (2021-11-29)
+
+- Initial commit

--- a/packages/bautajs-fastify-example/CHANGELOG.md
+++ b/packages/bautajs-fastify-example/CHANGELOG.md
@@ -8,4 +8,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 #### 1.0.0 (2021-11-29)
 
-- Initial commit
+- Add first version of a Bauta.js fastify project example.

--- a/packages/bautajs-fastify-example/LICENSE.TXT
+++ b/packages/bautajs-fastify-example/LICENSE.TXT
@@ -1,0 +1,25 @@
+The MIT License (MIT) Copyright © 2022 AXA Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+All AXA Companies constitute the "AXA Group" where "AXA Company" shall mean:
+
+(i) AXA, "Société Anonyme" with a Board of Directors (herein "AXA SA") having its principal offices at 25, avenue Matignon, 75008 Paris, registered on the Commercial Registry of Paris under the number 572 093 920; and
+
+(ii)    any other company controlled by, or controlling AXA SA, with a company being considered as controlling another:
+
+when it holds directly or indirectly a portion of the capital according to it the majority of the voting rights in general meetings of shareholders of this company;
+when it holds solely the majority of the voting rights in this company by virtue of an agreement concluded with other partners or shareholders and which is not contrary to the interest of the company;
+when it determines de facto, by voting rights which it holds, the decisions in the general meetings of shareholders of this company;
+in any event, when it holds, directly or indirectly, a portion of voting rights greater than 40% and when no other partner or shareholder holds directly or indirectly a portion which is greater than its own; and
+(iii)   any economic interest group or joint venture in which AXA SA and/or one or more other Companies of the AXA Group participates for at least 50% in operating costs;
+
+(iv)    in the cases where the law applicable to a company limits voting rights or control (such as defined here in above), this company will be deemed to be a company of the AXA Group, if the voting rights in general shareholders' meetings or the control held by a Company of the AXA Group reaches the maximum amount fixed by said applicable law; and
+
+(v) any legal entity in which an AXA company holds a lower portion of the capital or of voting rights or cost participation than set forth above when such company is authorized to do business under the name "AXA" or under a name which include the "AXA" business name;
+
+(vi)    and any other legal entity in which an AXA Company directly or indirectly has an economic interest. For the avoidance of doubt GIE AXA is deemed an AXA Company.

--- a/packages/bautajs-fastify-example/README.md
+++ b/packages/bautajs-fastify-example/README.md
@@ -2,7 +2,6 @@
 
 - This API example intends to show how you can use Bauta.js with Fastify.
 - This project example purpose is to showcase main features using simple examples. 
-```suggestion
 - This project example **does not** intend to show good practices using Node.js or security practices at all. Please be sure you follow security good practices on your Node.js API (i.e. adding [helmet](@fastify/helmet)).
 
 

--- a/packages/bautajs-fastify-example/README.md
+++ b/packages/bautajs-fastify-example/README.md
@@ -2,7 +2,8 @@
 
 - This API example intends to show how you can use Bauta.js with Fastify.
 - This project example purpose is to showcase main features using simple examples. 
-- This project example **does not** intend to show good practices using Node.js or security practices at all. Please be sure you follow security good practices on your Node.js API (i.e. adding [helmet](https://www.npmjs.com/package/helmet)).
+```suggestion
+- This project example **does not** intend to show good practices using Node.js or security practices at all. Please be sure you follow security good practices on your Node.js API (i.e. adding [helmet](@fastify/helmet)).
 
 
 ## Third party dependencies licenses

--- a/packages/bautajs-fastify-example/README.md
+++ b/packages/bautajs-fastify-example/README.md
@@ -1,0 +1,15 @@
+# bautajs-fastify-example
+
+- This API example intends to show how you can use Bauta.js with Fastify.
+- This project example purpose is to showcase main features using simple examples. 
+- This project example **does not** intend to show good practices using Node.js or security practices at all. Please be sure you follow security good practices on your Node.js API (i.e. adding [helmet](https://www.npmjs.com/package/helmet)).
+
+
+## Third party dependencies licenses
+
+### Production
+ - [@axa/bautajs-core@2.0.0](https://github.com/axa-group/bauta.js) - MIT*
+ - [@axa/bautajs-datasource-rest@2.0.0](https://github.com/axa-group/bauta.js) - MIT*
+ - [@axa/bautajs-decorator-cache@2.0.0](https://github.com/axa-group/bauta.js) - MIT*
+ - [@axa/bautajs-fastify@2.0.0](https://github.com/axa-group/bauta.js) - MIT*
+ - [fastify@4.8.1](https://github.com/fastify/fastify) - MIT

--- a/packages/bautajs-fastify-example/api-definition.json
+++ b/packages/bautajs-fastify-example/api-definition.json
@@ -1,0 +1,319 @@
+
+  {
+    "openapi": "3.0.0",
+    "info": {
+      "version": "v1",
+      "title": "Swagger Petstore",
+      "license": {
+        "name": "MIT"
+      }
+    },
+    "paths": {
+      "/v1/unused": {
+        "get": {
+          "summary": "An endpoint definition without resolver",
+          "operationId": "unused",
+          "responses": {
+            "200": {
+              "description": "Something!"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v1/randomYear": {
+        "get": {
+          "summary": "Provides information about a random year",
+          "operationId": "randomYear",
+          "responses": {
+            "200": {
+              "description": "Something!"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v1/randomYear2": {
+        "get": {
+          "summary": "Provides information about a random year",
+          "operationId": "randomYear2",
+          "responses": {
+            "200": {
+              "description": "Something!"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v1/factNumber/{number}": {
+        "get": {
+          "summary": "get a fact from a number",
+          "operationId": "factNumber",
+          "responses": {
+            "200": {
+              "description": "Something!"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v1/factNumber2/{number}": {
+        "get": {
+          "summary": "get a fact from a number",
+          "operationId": "factNumber2",
+          "responses": {
+            "200": {
+              "description": "Something!"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v1/articles": {
+        "get": {
+          "summary": "List all articles",
+          "operationId": "getAllArticles",
+          "tags": [
+            "articles"
+          ],
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "How many items to return at one time (max 100)",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "format": "int32"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "A paged array of articles",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Articles"
+                  }
+                }
+              }
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v1/no-pipeline": {
+        "get": {
+          "summary": "Endpoint without pipeline",
+          "operationId": "noPipeline",
+          "tags": [
+            "articles"
+          ],
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "How many items to return at one time (max 100)",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "format": "int32"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "A paged array of articles"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v1/cats": {
+        "get": {
+          "summary": "List all fact cats",
+          "operationId": "cats",
+          "responses": {
+            "200": {
+              "description": "Something!"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Cats"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v1/chuckfacts/{string}": {
+        "get": {
+          "summary": "get a list of facts related to Chuck Norris",
+          "operationId": "chuckFacts",
+          "responses": {
+            "200": {
+              "description": "Something!"
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Error"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "ThisShouldNotBeIncluded": {
+          "required": [
+            "userId",
+            "title"
+          ],
+          "properties": {
+            "userId": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "title": {
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            }
+          }
+        },
+        "Article": {
+          "required": [
+            "title"
+          ],
+          "properties": {
+            "userId": {
+              "nullable": true,
+              "type": "integer",
+              "format": "int64"
+            },
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "title": {
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            }
+          }
+        },
+        "Articles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/Article"
+          }
+        },
+        "Cat": {
+          "required": [
+            "text"
+          ],
+          "properties": {
+            "text": {
+              "type": "string"
+            }
+          }
+        },
+        "Cats": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/Cat"
+          }
+        },
+        "Error": {
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/packages/bautajs-fastify-example/package.json
+++ b/packages/bautajs-fastify-example/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@axa/bautajs-fastify-example",
+  "version": "2.0.1",
+  "description": "A bautaJS example in fastify",
+  "main": "./server.js",
+  "scripts": {
+    "start": "LOG_LEVEL=info DEBUG=bautajs* node ./server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/axa-group/bauta.js"
+  },
+  "private": true,
+  "keywords": [
+    "bautajs",
+    "fastify",
+    "middleware"
+  ],
+  "license": "SEE LICENSE IN LICENSE.txt",
+  "dependencies": {
+    "@axa/bautajs-core": "^2.0.1",
+    "@axa/bautajs-datasource-rest": "^2.0.1",
+    "@axa/bautajs-decorator-cache": "^2.0.1",
+    "@axa/bautajs-fastify": "^2.0.1",
+    "fastify": "^4.8.1"
+  }
+}

--- a/packages/bautajs-fastify-example/registrator.js
+++ b/packages/bautajs-fastify-example/registrator.js
@@ -1,0 +1,28 @@
+const { bautajsFastify, logger } = require('@axa/bautajs-fastify');
+const apiDefinition = require('./api-definition.json');
+const { logRequest } = require('./server/hooks/logger-hook');
+
+async function registerFastifyServer(fastify) {
+  fastify.addHook('onRequest', logRequest);
+
+  fastify
+    .register(bautajsFastify, {
+      apiDefinition,
+      prefix: '',
+      apiBasePath: '/',
+      resolversPath: './server/resolvers/**/*.js',
+      staticConfig: {
+        someVar: 2
+      }
+    })
+    .after(err => {
+      if (err) {
+        logger.error(err, 'Error on fastify server');
+        throw err;
+      }
+    });
+}
+
+module.exports = {
+  registerFastifyServer
+};

--- a/packages/bautajs-fastify-example/server.js
+++ b/packages/bautajs-fastify-example/server.js
@@ -1,0 +1,18 @@
+const fastify = require('fastify')({ logger: true });
+
+const { registerFastifyServer } = require('./registrator');
+
+(async () => {
+  await registerFastifyServer(fastify);
+
+  fastify.listen(
+    {
+      host: '0.0.0.0',
+      port: 8080
+    },
+    err => {
+      if (err) throw err;
+      fastify.log.info('Server listening on localhost:', fastify.server.address().port);
+    }
+  );
+})();

--- a/packages/bautajs-fastify-example/server/hooks/logger-hook.js
+++ b/packages/bautajs-fastify-example/server/hooks/logger-hook.js
@@ -1,0 +1,9 @@
+function logRequest(request, reply, done) {
+  // eslint-disable-next-line no-console
+  console.log(`this would be a logRequest: ${request.url}`);
+  return done();
+}
+
+module.exports = {
+  logRequest
+};

--- a/packages/bautajs-fastify-example/server/resolvers/v1/source/articles-datasource.js
+++ b/packages/bautajs-fastify-example/server/resolvers/v1/source/articles-datasource.js
@@ -1,0 +1,16 @@
+const { getRequest } = require('@axa/bautajs-fastify');
+const { restProvider } = require('@axa/bautajs-datasource-rest');
+
+module.exports.getAllArticles = restProvider(async (client, _, ctx, bautajs) => {
+  const req = getRequest(ctx);
+
+  return client.get(`https://jsonplaceholder.typicode.com/posts`, {
+    cache: new Map(),
+    reqId: req.query.a,
+    method: 'GET',
+    headers: {
+      'custom-header': bautajs.staticConfig.someVar,
+      resolveBodyOnly: true
+    }
+  });
+});

--- a/packages/bautajs-fastify-example/server/resolvers/v1/source/articles-resolver.js
+++ b/packages/bautajs-fastify-example/server/resolvers/v1/source/articles-resolver.js
@@ -1,0 +1,31 @@
+const { pipe, match, resolver } = require('@axa/bautajs-core');
+const { getAllArticles } = require('./articles-datasource');
+
+const myPipelineTwo = pipe((response, ctx) => {
+  ctx.log.info('pipeline 2');
+
+  return response;
+});
+
+const myPipeline = pipe((response, ctx) => {
+  ctx.log.info('pipeline 1');
+  return response;
+});
+
+module.exports = resolver(operations => {
+  operations.getAllArticles
+    .validateRequest(false)
+    .validateResponse(false)
+    .setup(
+      pipe(
+        getAllArticles(),
+        match(m =>
+          m
+            .on(prev => {
+              return prev === null;
+            }, myPipeline)
+            .otherwise(myPipelineTwo)
+        )
+      )
+    );
+});

--- a/packages/bautajs-fastify-example/server/resolvers/v1/source/cache-resolver.js
+++ b/packages/bautajs-fastify-example/server/resolvers/v1/source/cache-resolver.js
@@ -1,0 +1,23 @@
+const { getRequest } = require('@axa/bautajs-fastify');
+const { pipe, resolver, step } = require('@axa/bautajs-core');
+const { cache } = require('@axa/bautajs-decorator-cache');
+const { chuckProvider } = require('./chuck-datasource');
+
+const transformResponse = step(response => {
+  return {
+    message: JSON.stringify(response)
+  };
+});
+
+const normalizer = (_, ctx) => {
+  const req = getRequest(ctx);
+  return req.params.string;
+};
+
+const chuckFactsPipeline = pipe(chuckProvider(), transformResponse);
+
+const cachedChuckFactsPipeline = pipe(cache(chuckFactsPipeline, { maxSize: 2 }, normalizer));
+
+module.exports = resolver(operations => {
+  operations.chuckFacts.setup(cachedChuckFactsPipeline);
+});

--- a/packages/bautajs-fastify-example/server/resolvers/v1/source/cats-datasource.js
+++ b/packages/bautajs-fastify-example/server/resolvers/v1/source/cats-datasource.js
@@ -1,0 +1,12 @@
+const { restProvider } = require('@axa/bautajs-datasource-rest');
+
+// Used to test that an https works
+const catsRestProviderWithHttps = restProvider(client => {
+  return client.get('https://cat-fact.herokuapp.com/facts', {
+    https: { rejectUnauthorized: false }
+  });
+});
+
+module.exports = {
+  catsRestProviderWithHttps
+};

--- a/packages/bautajs-fastify-example/server/resolvers/v1/source/chuck-datasource.js
+++ b/packages/bautajs-fastify-example/server/resolvers/v1/source/chuck-datasource.js
@@ -8,7 +8,7 @@ const chuckProvider = restProvider(async (client, _, ctx) => {
   const result = await client.get(
     `https://api.chucknorris.io/jokes/search?query=${req.params.string}`,
     {
-      rejectUnauthorized: false,
+      https: { rejectUnauthorized: false },
       resolveBodyOnly: true
     }
   );

--- a/packages/bautajs-fastify-example/server/resolvers/v1/source/chuck-datasource.js
+++ b/packages/bautajs-fastify-example/server/resolvers/v1/source/chuck-datasource.js
@@ -1,0 +1,21 @@
+const { getRequest } = require('@axa/bautajs-fastify');
+const { restProvider } = require('@axa/bautajs-datasource-rest');
+
+// Used to test that an https works
+const chuckProvider = restProvider(async (client, _, ctx) => {
+  const req = getRequest(ctx);
+
+  const result = await client.get(
+    `https://api.chucknorris.io/jokes/search?query=${req.params.string}`,
+    {
+      rejectUnauthorized: false,
+      resolveBodyOnly: true
+    }
+  );
+
+  return result;
+});
+
+module.exports = {
+  chuckProvider
+};

--- a/packages/bautajs-fastify-example/server/resolvers/v1/source/numbers-datasource.js
+++ b/packages/bautajs-fastify-example/server/resolvers/v1/source/numbers-datasource.js
@@ -1,0 +1,28 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { getRequest } = require('@axa/bautajs-fastify');
+const { restProvider } = require('@axa/bautajs-datasource-rest');
+
+const exampleRestProviderYear = restProvider(async (client, _prv, ctx) => {
+  const req = getRequest(ctx);
+  const result = await client.get('http://numbersapi.com/random/year?json', {
+    headers: req.headers,
+    resolveBodyOnly: false
+  });
+
+  return result.body.text;
+});
+
+const exampleRestProvider = restProvider(async (client, _prv, ctx) => {
+  const req = getRequest(ctx);
+
+  return client.get(`http://numbersapi.com/${req.params.number}/math`, {
+    responseType: 'text',
+    resolveBodyOnly: true,
+    headers: req.headers
+  });
+});
+
+module.exports = {
+  exampleRestProviderYear,
+  exampleRestProvider
+};

--- a/packages/bautajs-fastify-example/server/resolvers/v1/source/numbers-resolver.js
+++ b/packages/bautajs-fastify-example/server/resolvers/v1/source/numbers-resolver.js
@@ -1,0 +1,42 @@
+const { pipe, step, resolver } = require('@axa/bautajs-core');
+const { exampleRestProviderYear, exampleRestProvider } = require('./numbers-datasource');
+const { catsRestProviderWithHttps } = require('./cats-datasource');
+
+const transformResponse = step(response => {
+  return {
+    message: response
+  };
+});
+
+const transformCatsResponse = step(response => {
+  return response.map(c => ({
+    text: c.text
+  }));
+});
+
+module.exports = resolver(operations => {
+  operations.randomYear
+    .validateRequest(false)
+    .validateResponse(false)
+    .setup(pipe(exampleRestProviderYear(), transformResponse));
+
+  operations.randomYear2
+    .validateRequest(false)
+    .validateResponse(false)
+    .setup(pipe(exampleRestProviderYear(), transformResponse));
+
+  operations.factNumber
+    .validateRequest(false)
+    .validateResponse(false)
+    .setup(pipe(exampleRestProvider(), transformResponse));
+
+  operations.factNumber2
+    .validateRequest(false)
+    .validateResponse(false)
+    .setup(pipe(exampleRestProvider(), transformResponse));
+
+  operations.cats
+    .validateRequest(false)
+    .validateResponse(false)
+    .setup(pipe(catsRestProviderWithHttps(), transformCatsResponse));
+});


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated documentation for any new behavior.

## PR Description

Closes #33 

This is a similar example that we have in [bautajs-express-example](https://github.com/axa-group/bauta.js/tree/main/packages/bautajs-express-example) but using fastify v4 instead of express.

The defined endpoints are the same, and the changes in structure and the code are to reflect the different patterns we use in fastify and the fact that fastify schema validator behaves slightly different than the one from express (it is more strict and ignores anything that is not in the schema).

We add the link to this new package in the Readme.md root folder.