### PR TITLE
fix(bautajs-express-example, bautajs-fastify-example): add service to showcase request cancellation

### DIFF
--- a/packages/bautajs-express-example/README.md
+++ b/packages/bautajs-express-example/README.md
@@ -37,6 +37,8 @@
 - GET `api/multiple-path/{key}`
 - GET `api/multiple-path/specific`
   - These two endpoints help understand how the route ordering works
+- GET `api/cancel/{number}`
+  - Returns a string if number is less than 10 seconds. Aborts after 10 seconds in the rest of the cases.
 
 
 ## Custom Logger example

--- a/packages/bautajs-express-example/api-definition.json
+++ b/packages/bautajs-express-example/api-definition.json
@@ -30,6 +30,38 @@
         }
       }
     },
+    "/cancel/{number}": {
+      "get": {
+        "summary": "service to test cancel request. Waits number seconds until an answer is given but cancel if number is greather than 10 seconds",
+        "operationId": "cancelRequest",
+        "parameters": [
+          {
+            "name": "number",
+            "in": "path",
+            "description": "The number of seconds to wait",
+            "required": true,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Something!"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/randomYear": {
       "get": {
         "summary": "Provides information about a random year",

--- a/packages/bautajs-express-example/server/resolvers/cancel-request-resolver.js
+++ b/packages/bautajs-express-example/server/resolvers/cancel-request-resolver.js
@@ -1,0 +1,43 @@
+const { resolver, pipe, step } = require('@axa/bautajs-core');
+const { getRequest } = require('@axa/bautajs-express');
+
+const transformResponse = step(response => {
+  return {
+    message: response
+  };
+});
+
+function getNumberFromRequestStep(_prev, ctx) {
+  const req = getRequest(ctx);
+
+  const { number } = req.params;
+
+  return number;
+}
+
+function giveAnswerAfterWaitingWithTimeout() {
+  return step(async (number, ctx) => {
+    const timeout = number * 1000;
+    const promiseAnswer = new Promise(resolve =>
+      setTimeout(() => {
+        resolve(`We have waited for ${number} seconds`);
+      }, timeout)
+    );
+
+    const cancelator = new Promise(resolve =>
+      setTimeout(() => {
+        ctx.token.cancel(); // If this triggers the promise does not resolve but it is cancelled
+        resolve('ended');
+      }, 10000)
+    );
+
+    return Promise.race(await [promiseAnswer, cancelator]);
+  });
+}
+
+module.exports = resolver(operations => {
+  operations.cancelRequest
+    .validateRequest(false)
+    .validateResponse(false)
+    .setup(pipe(getNumberFromRequestStep, giveAnswerAfterWaitingWithTimeout(), transformResponse));
+});

--- a/packages/bautajs-fastify-example/README.md
+++ b/packages/bautajs-fastify-example/README.md
@@ -37,6 +37,9 @@
 - GET `api/multiple-path/{key}`
 - GET `api/multiple-path/specific`
   - These two endpoints help understand how the route ordering works
+- GET `api/cancel/{number}`
+  - Returns a string if number is less than 10 seconds. Aborts after 10 seconds in the rest of the cases.
+
 
 ## Third party dependencies licenses
 

--- a/packages/bautajs-fastify-example/api-definition.json
+++ b/packages/bautajs-fastify-example/api-definition.json
@@ -30,6 +30,38 @@
         }
       }
     },
+    "/cancel/{number}": {
+      "get": {
+        "summary": "service to test cancel request. Waits number seconds until an answer is given but cancel if number is greather than 10 seconds",
+        "operationId": "cancelRequest",
+        "parameters": [
+          {
+            "name": "number",
+            "in": "path",
+            "description": "The number of seconds to wait",
+            "required": true,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Something!"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/randomYear": {
       "get": {
         "summary": "Provides information about a random year",

--- a/packages/bautajs-fastify-example/server/resolvers/cancel-request-resolver.js
+++ b/packages/bautajs-fastify-example/server/resolvers/cancel-request-resolver.js
@@ -1,0 +1,43 @@
+const { resolver, pipe, step } = require('@axa/bautajs-core');
+const { getRequest } = require('@axa/bautajs-fastify');
+
+const transformResponse = step(response => {
+  return {
+    message: response
+  };
+});
+
+function getNumberFromRequestStep(_prev, ctx) {
+  const req = getRequest(ctx);
+
+  const { number } = req.params;
+
+  return number;
+}
+
+function giveAnswerAfterWaitingWithTimeout() {
+  return step(async (number, ctx) => {
+    const timeout = number * 1000;
+    const promiseAnswer = new Promise(resolve =>
+      setTimeout(() => {
+        resolve(`We have waited for ${number} seconds`);
+      }, timeout)
+    );
+
+    const cancelator = new Promise(resolve =>
+      setTimeout(() => {
+        ctx.token.cancel(); // If this triggers the promise does not resolve but it is cancelled
+        resolve('ended');
+      }, 10000)
+    );
+
+    return Promise.race(await [promiseAnswer, cancelator]);
+  });
+}
+
+module.exports = resolver(operations => {
+  operations.cancelRequest
+    .validateRequest(false)
+    .validateResponse(false)
+    .setup(pipe(getNumberFromRequestStep, giveAnswerAfterWaitingWithTimeout(), transformResponse));
+});


### PR DESCRIPTION
## PR Checklist

- [x] I have added/updated documentation for any new behavior.

## PR Description

This does not solve anything by itself but it is a previous/helpful step to try to solve the issue #65.

Basically we have added a new endpoint to both fastify and express example services:

- service GET api/cancel/{number}
  - if number is less than 10: the endpoint waits that number of seconds and returns a string.
  - if number is greater than 10: the endpoint will wait 10 seconds and will cancel the request at that moment.

This showcases request cancellations inside bauta pipelines and provides a playground for issue #65.



--- 


![](https://upload.wikimedia.org/wikipedia/commons/7/78/Hieronymus_Bosch_-_Triptych_of_Garden_of_Earthly_Delights_%28detail%29_-_WGA2525.jpg)
