### PR TITLE
fix(fastify): prevent error when schema members are undefined

### DIFF
--- a/packages/bautajs-fastify/src/expose-routes.ts
+++ b/packages/bautajs-fastify/src/expose-routes.ts
@@ -123,15 +123,27 @@ async function exposeRoutes(
     const method: fastify.HTTPMethods = (operation.route?.method.toUpperCase() ||
       'GET') as fastify.HTTPMethods;
     const { url = '' } = operation.route || {};
-    const requestSchema =
-      operation.route?.schema && operation.requestValidationEnabled
-        ? {
-            body: operation.route?.schema.body,
-            params: operation.route?.schema.params,
-            headers: operation.route?.schema.headers,
-            querystring: operation.route?.schema.querystring
-          }
-        : {};
+    const requestSchema: any = {};
+    // Avoid defining the request schema member as undefined
+    // to prevent https://github.com/fastify/fastify/issues/4634
+    if (operation.route?.schema && operation.requestValidationEnabled) {
+      if (operation.route?.schema.body) {
+        requestSchema.body = operation.route?.schema.body;
+      }
+
+      if (operation.route?.schema.params) {
+        requestSchema.params = operation.route?.schema.params;
+      }
+
+      if (operation.route?.schema.headers) {
+        requestSchema.headers = operation.route?.schema.headers;
+      }
+
+      if (operation.route?.schema.querystring) {
+        requestSchema.querystring = operation.route?.schema.querystring;
+      }
+    }
+
     const responseSchema = operation.route?.schema
       ? { response: operation.route?.schema.response }
       : {};


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] I have added/updated documentation for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

<!-- Describe Your PR Here! -->

With Fastify v4.15.0, the following change in managing schema validation was introduced, https://github.com/fastify/fastify/pull/4620. It caused our tests for `bautajs-fastify` to fail. 

This PR avoids the definition of _undefined_ schema members to prevent the new Fastify behaviour and the errors it is throwing now.
