### PR TITLE
fix(core): remove waiting for pipeline settlement

### DIFF
--- a/docs/decorators/tap.md
+++ b/docs/decorators/tap.md
@@ -1,8 +1,12 @@
 # tap decorator
 
-Decorator that allows to transparently perform actions or side-effects, such as logging without loosing the previous step result. You can explore the source code [here](../../packages/bautajs-core/src/decorators/tap.ts).
+Decorator that allows to transparently perform actions or side-effects, such as logging without losing the previous step result. You can explore the source code [here](../../packages/bautajs-core/src/decorators/tap.ts).
 
-## Example
+In case that the tapped pipeline behaves asynchronously, its execution will be done in parallel but its result will be ignored (be it resolved value or a rejected error). Note that any side effect that happens
+during this execution pipeline will take place even if its initial request has finished.
+
+
+## Examples
 
 ### 1. Do a console log
 
@@ -27,3 +31,37 @@ Decorator that allows to transparently perform actions or side-effects, such as 
 // => 'some intermediate step. Prev is I am so random!'
 // => 'I am so random!'
 ```
+
+### 2. Tap an asynchronous and slow task
+
+```javascript
+  const { tap, step, pipe } = require('@axa/bautajs-core');
+
+  const randomPreviousStep = step(() => 'I am so random!');
+
+   const pipeline = pipe(
+     randomPreviousStep,
+     tap((prev) => {
+       console.log('we are inside the tap!');
+
+       await delay(a_lot_of_time);
+
+       await executeASideEffect();
+
+       console.log('we may have made some side effects!' );
+       return 'this value will be lost';
+     }),
+     (prev) => {
+       console.log(prev);
+     }
+   );
+
+Assuming there is no error in the execution of the pipeline:
+// => 'we are inside the tap!'
+// => 'I am so random!'
+// ...
+// => 'we may have made some side effects!'
+
+```
+
+

--- a/packages/bautajs-core/src/decorators/__tests__/tap.test.ts
+++ b/packages/bautajs-core/src/decorators/__tests__/tap.test.ts
@@ -34,9 +34,10 @@ describe('tap decorator', () => {
 
   test('should perform asynchronously the current step action but return the previous step value', async () => {
     const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    const delayToCheck = 50;
     const log = jest.fn();
     const tappedPromise = async (name: string) => {
-      await delay(100);
+      await delay(delayToCheck);
       return log(name);
     };
     const getMovie = step(() => ({ name: 'star wars' }));
@@ -46,18 +47,23 @@ describe('tap decorator', () => {
       tap(step<{ name: string }, { name: string }>(async ({ name }) => tappedPromise(name)))
     );
 
-    await expect(pipeline({}, createContext({}), {} as BautaJSInstance)).resolves.toStrictEqual({
-      name: 'star wars'
-    });
-
+    const start = new Date().getTime();
+    const result = await pipeline({}, createContext({}), {} as BautaJSInstance);
+    // At the moment that we return from the pipeline execution, the log inside tappedPromise has not been called
+    expect(log).not.toHaveBeenCalledWith('star wars');
+    expect(result).toStrictEqual({ name: 'star wars' });
+    expect(new Date().getTime() - start).toBeLessThan(delayToCheck);
+    await delay(delayToCheck);
+    // After waiting for a bit, even when the pipeline has returned the code inside the tapped promise is executed in parallel and "forgotten"
     expect(log).toHaveBeenCalledWith('star wars');
   });
 
   test('should ignore the error inside tap and return the previous step value', async () => {
     const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    const delayToCheck = 50;
 
     const tappedPromise = async (name: string) => {
-      await delay(100);
+      await delay(delayToCheck);
 
       return Promise.reject(new Error(`We have an error: ${name}`));
     };
@@ -68,8 +74,9 @@ describe('tap decorator', () => {
       tap(step<{ name: string }, { name: string }>(async ({ name }) => tappedPromise(name)))
     );
 
-    await expect(pipeline({}, createContext({}), {} as BautaJSInstance)).resolves.toStrictEqual({
-      name: 'star wars'
-    });
+    const start = new Date().getTime();
+    const result = await pipeline({}, createContext({}), {} as BautaJSInstance);
+    expect(result).toStrictEqual({ name: 'star wars' });
+    expect(new Date().getTime() - start).toBeLessThan(delayToCheck);
   });
 });

--- a/packages/bautajs-core/src/decorators/tap.ts
+++ b/packages/bautajs-core/src/decorators/tap.ts
@@ -6,10 +6,11 @@ import { isPromise } from '../utils/is-promise';
  * such as logging and return the previous step result.
  *
  * Tap supports promises, but it will ignore any error thrown inside the tapped
- * promise and will wait for its execution just to ignore its value.
+ * promise and will not wait for its resolution, thus ignoring its value.
  *
  * The step inside tap does not need to return anything, since if it returns anything,
  * it will be ignored anyways in favour of what was in the previous step.
+ *
  *
  * @param {Pipeline.StepFunction<TIn, any>} stepFn - The step fn to execute
  * @returns {Pipeline.StepFunction<TIn, TIn>}
@@ -44,7 +45,7 @@ export function tap<TIn>(
     const result = stepFn(prev, ctx, bautajs);
 
     if (isPromise(result)) {
-      return (result as Promise<typeof result>).then(() => prev).catch(() => prev);
+      (result as Promise<typeof result>).catch(() => prev);
     }
     return prev;
   };


### PR DESCRIPTION

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] I have added/updated documentation for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## We do not wait for the settlement of the pipeline inside tap if it is a promise

Fixes #89. 


![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmVmN2Q4YzE1ZTI3NzY5ODg1ZDliN2NlYzM3MDM3ODkxOWMzMWFkNSZlcD12MV9pbnRlcm5hbF9naWZzX2dpZklkJmN0PWc/cqf5wzvVMiYDe/giphy.gif) 
