### PR TITLE
fix(ci, build, fastify): add type casting to prevent build error

### DIFF
--- a/packages/bautajs-fastify/src/expose-routes.ts
+++ b/packages/bautajs-fastify/src/expose-routes.ts
@@ -41,7 +41,7 @@ function createHandler(operation: Operation) {
     const op = operation.run<{ req: fastify.FastifyRequest; res: fastify.FastifyReply }, any>({
       req: request,
       res: reply,
-      id: request.id || request.headers['x-request-id'],
+      id: (request.id || request.headers['x-request-id']) as string,
       url: request.url,
       log: request.log
     });


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.

## PR Description

<!-- Describe Your PR Here! -->
Avoiding the following typescript error on build.

```console
  > @axa/bautajs-fastify@3.0.0-alpha.2 build
  > tsc --build
  
  Error: src/expose-routes.ts(44,7): error TS2322: Type 'string | string[] | undefined' is not assignable to type 'string | undefined'.
    Type 'string[]' is not assignable to type 'string'.
```
