### PR TITLE
feat: remove support for Node.js 16.x and add for 20.x

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,9 +18,9 @@ If applicable, add screenshots to help explain your problem.
 
 ### Desktop (please complete the following information):\*\*
 
-- OS: [e.g. Linux, MacOSX, Windows 10]
+- OS: [e.g. Linux, MacOSX, Windows 11]
 - fp-toolbox version [e.g. v1.0.0]
-- Node.js version [e.g. v12.14.1]
+- Node.js version [e.g. v20.8.1]
 
 ### Additional context
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,8 @@ Bauta.js will deprecate the non-supported Node.js version following the Release 
 
 | Version          | Supported          |
 | ---------------- | ------------------ |
-| Node.js 16.x     | :white_check_mark: |
 | Node.js 18.x     | :white_check_mark: |
+| Node.js 20.x     | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/axa-group/bauta.js#readme",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "benchmark-core": "npx concurrently -k -s first \"node ./packages/bautajs-core/benchmark/simple.js\" \"npx autocannon -c 100 -d 5 -p 10 localhost:3000/api/op1\"",

--- a/packages/bautajs-core/package.json
+++ b/packages/bautajs-core/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": ">=8"
   },
   "dependencies": {

--- a/packages/bautajs-datasource-rest/package.json
+++ b/packages/bautajs-datasource-rest/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": ">=8"
   },
   "dependencies": {

--- a/packages/bautajs-datasource-rest/test/datasource-rest.test.ts
+++ b/packages/bautajs-datasource-rest/test/datasource-rest.test.ts
@@ -1298,7 +1298,8 @@ describe('provider rest', () => {
               code: 'ERR_BODY_PARSE_FAILURE',
               body: 'this is not a json and this will generate a parser error',
               statusCode: 200,
-              message: 'Unexpected token h in JSON at position 1 in "https://pets.com/v1/policies"',
+              message:
+                'Unexpected token \'h\', "this is not"... is not valid JSON in "https://pets.com/v1/policies"',
               name: 'ParseError'
             }),
             datasourceReq: {
@@ -1341,7 +1342,9 @@ describe('provider rest', () => {
         }
 
         await expect(providerThrowsAnError()).rejects.toThrow(
-          new Error('Unexpected token w in JSON at position 0 in "https://pets.com/v1/policies"')
+          new Error(
+            'Unexpected token \'w\', "we force w"... is not valid JSON in "https://pets.com/v1/policies"'
+          )
         );
 
         expect(logger.error).toHaveBeenCalledTimes(1); // We check error logging in another test
@@ -1367,7 +1370,8 @@ describe('provider rest', () => {
           {
             datasourceErr: expect.objectContaining({
               code: 'ERR_BODY_PARSE_FAILURE',
-              message: 'Unexpected token w in JSON at position 0 in "https://pets.com/v1/policies"',
+              message:
+                'Unexpected token \'w\', "we force w"... is not valid JSON in "https://pets.com/v1/policies"',
               name: 'ParseError',
               body: 'we force with this a parserError',
               headers: {},
@@ -1407,7 +1411,9 @@ describe('provider rest', () => {
         }
 
         await expect(providerThrowsAnError()).rejects.toThrow(
-          new Error('Unexpected token < in JSON at position 0 in "https://pets.com/v1/policies"')
+          new Error(
+            'Unexpected token \'<\', "<html><div"... is not valid JSON in "https://pets.com/v1/policies"'
+          )
         );
       });
     });

--- a/packages/bautajs-datasource-rest/test/datasource-rest.test.ts
+++ b/packages/bautajs-datasource-rest/test/datasource-rest.test.ts
@@ -1298,8 +1298,6 @@ describe('provider rest', () => {
               code: 'ERR_BODY_PARSE_FAILURE',
               body: 'this is not a json and this will generate a parser error',
               statusCode: 200,
-              message:
-                'Unexpected token \'h\', "this is not"... is not valid JSON in "https://pets.com/v1/policies"',
               name: 'ParseError'
             }),
             datasourceReq: {
@@ -1341,11 +1339,7 @@ describe('provider rest', () => {
           return provider()(null, ctx, bautajs);
         }
 
-        await expect(providerThrowsAnError()).rejects.toThrow(
-          new Error(
-            'Unexpected token \'w\', "we force w"... is not valid JSON in "https://pets.com/v1/policies"'
-          )
-        );
+        await expect(providerThrowsAnError()).rejects.toThrowError();
 
         expect(logger.error).toHaveBeenCalledTimes(1); // We check error logging in another test
 
@@ -1370,8 +1364,6 @@ describe('provider rest', () => {
           {
             datasourceErr: expect.objectContaining({
               code: 'ERR_BODY_PARSE_FAILURE',
-              message:
-                'Unexpected token \'w\', "we force w"... is not valid JSON in "https://pets.com/v1/policies"',
               name: 'ParseError',
               body: 'we force with this a parserError',
               headers: {},
@@ -1410,11 +1402,7 @@ describe('provider rest', () => {
           return provider()(null, ctx, bautajs);
         }
 
-        await expect(providerThrowsAnError()).rejects.toThrow(
-          new Error(
-            'Unexpected token \'<\', "<html><div"... is not valid JSON in "https://pets.com/v1/policies"'
-          )
-        );
+        await expect(providerThrowsAnError()).rejects.toThrowError();
       });
     });
   });

--- a/packages/bautajs-express/package.json
+++ b/packages/bautajs-express/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": ">=8"
   },
   "dependencies": {

--- a/packages/bautajs-fastify/package.json
+++ b/packages/bautajs-fastify/package.json
@@ -28,7 +28,7 @@
     "middleware"
   ],
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": ">=8"
   },
   "license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
# Drop Node.js 16.x support & add Node.js 20.x LTS support

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] I have added/updated documentation for any new behavior.

## PR Description

<!-- Describe Your PR Here! -->

The breaking change in this pull request is the dropping of support for Node.js 16.x. Node.js 16.x is no longer actively maintained and has reached its end of life, which means it will no longer receive updates or security patches. This decision may impact projects that rely on features or behaviors specific to Node.js 16.x. Developers and maintainers should be prepared to update their code to be compatible with Node.js 20.x, which introduces new features, updates, and potential differences in behavior. It is recommended to review the Node.js release notes for version 20.x to understand these changes thoroughly.
