### PR TITLE
chore: update eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,7 +65,7 @@
       }
     ],
     "no-promise-executor-return": 0,
-    "class-methods-use-this": "warn",
+   "class-methods-use-this": ["error", { "enforceForClassFields": false }],
     "import/extensions": [
       "error",
       "always",

--- a/.eslintrc
+++ b/.eslintrc
@@ -65,7 +65,7 @@
       }
     ],
     "no-promise-executor-return": 0,
-   "class-methods-use-this": ["error", { "enforceForClassFields": false }],
+    "class-methods-use-this": ["error", { "enforceForClassFields": false }],
     "import/extensions": [
       "error",
       "always",


### PR DESCRIPTION
# Pull Request Template
Fixes #46 

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [] I have added/updated tests for any new behavior.
- [] I have added/updated documentation for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #46

## PR Description

Changed the "class-methods-use-this" field in eslintrc from "warn" to ["error", { "enforceForClassFields": false }] so classes don't just get a warning when they use the "this" keyword incorrectly but they error.
