### PR TITLE
feat(bautajs-core): update tap behaviour to make it consistent

### DIFF
--- a/docs/decorators/tap.md
+++ b/docs/decorators/tap.md
@@ -1,14 +1,14 @@
-# tap decorator
+# `tap` decorator
 
 Decorator that allows to transparently perform actions or side-effects, such as logging without loosing the previous step result. You can explore the source code [here](../../packages/bautajs-core/src/decorators/tap.ts).
 
-## tap decorator flow
+## `tap` decorator flow
 
 The `tap` decorator accepts any number of step functions and executes them sequentially.
 
 The `tap` decorator behaviour in a few words:
 
-If all goes well (no errors), at the end of the `tap` decorator execution, you will get as the result of this decorator the value returned by the previous step of this decorator (or in other words, the first element received by the first step function of the tap decorator).
+If all goes well (no errors), at the end of the `tap` decorator execution, you will get as the result of this decorator the value returned by the previous step of this decorator (or in other words, the first element received by the first step function of the `tap` decorator).
 
 If there is an error, the error will be managed by the error handler attached to the decorator (be it the default one or a custom set through the `catchError` function). This can end in two cases: 
 - the error handler throws an error --> then this error is thrown by the `tap` decorator
@@ -19,27 +19,41 @@ If there is an error, the error will be managed by the error handler attached to
 At the end of `tap` decorator you will get:
 
 - an error that has interrupted the step function flow
-- the same value that was received by the first step function of the tap decorator if no error was triggered and thrown.
+- the same value that was received by the first step function of the `tap` decorator if no error was triggered and thrown.
 
-## tap decorator usage
 
-There are two use cases where this decorator is useful:
+### the flow inside `tap` is sequential as a normal pipeline
 
-1. Synchronous Logging without need to return the previous value
-2. Asynchronous validation without need to drag the value between steps: this simplifies the pattern of usage because you do not need to worry about maintaining the value that you want to use *after* the validation or have to worry about mappings like when using `pairwise`.
+While at the end of the step functions decorated by `tap` you get the input value of the first step, the execution INSIDE `tap` follows the step function pattern in which the values are passed between steps.
 
-### Caution
+```js
+export function thisIsAGoodPipeline() {
+  return pipe(
+    stepFunctionReturnsAAA,    
+    tap(
+      stepFunctionReturnsBBB,     // --> input parameter of stepFunctionReturnsBBB is AAA
+      stepFunctionReturnsCCC,     // --> input parameter of stepFunctionReturnsCCC is BBB (not AAA)
+      stepFunctionReturnsDDD      // --> input parameter of stepFunctionReturnsDDD is CCC (not AAA)
+    ),
+    stepFunctionReturnsEEE        // --> input parameter of stepFunctionReturnsEEE is AAA (CCC is lost)
+  );
+}
 
-The tap decorator is very useful to proc side effects knowing that at the end you will get the origin value, but it can make readibility hard if you compose a lot of nested functions inside it. Our advice is to create steps accordingly and call them from the decorator to improve readibility.
+
+```
+
+### Beware nesting step functions inside tap
+
+The `tap` decorator is useful to process side effects knowing that at the end you will get the origin value, but it can make readibility hard if you compose a lot of nested functions inside it. Our advice is to create steps accordingly and call them from the decorator to improve readibility.
 
 ```javascript
 // do this
 export function thisIsAGoodPipeline() {
   return pipe(
-   firstStepFunction,
-    secondStepFunction(),
-    tap(sideEffectValidationStepFunction()),
-    thirdStepFunction()
+    firstStepFunction,
+    secondStepFunction,
+    tap(sideEffectValidationStepFunction),
+    thirdStepFunction
   );
 }
 
@@ -47,17 +61,35 @@ export function thisIsAGoodPipeline() {
 export function thisIsABadPipeline() {
   return pipe(
    firstStepFunction,
-    secondStepFunction(),
+    secondStepFunction,
     tap(async(prev, ctx, bautajs) => {
       // Code to access database
       // Code to validate certain rules
       // Code to decide whether the rules are meet or not and possibly throw an error
     }),
-    thirdStepFunction()
+    thirdStepFunction
   );
 }
 
 ```
+
+### error handling and custom error handling limitations
+
+The `tap` decorator allows for a custom error handler. If you do not provide any, the default behaviour is just throw the error through the decorator.
+
+Two considerations are important if you decide to provide a custom error handling:
+
+- First: the error handling function must be synchronous. 
+
+- Second: you may ignore any error inside tap through your custom error handling function but the value returned nevertheless will always be the input of the first step function of the decorator, *regardless* of what value you may put in this custom error handler. This is because `tap` deals only with side effects inside their step functions.
+
+## `tap` decorator usage
+
+There are two use cases where this decorator is useful:
+
+1. Synchronous Logging without need to return the previous value
+2. Asynchronous validation without need to drag the value between steps: this simplifies the pattern of usage because you do not need to worry about maintaining the value that you want to use *after* the validation or have to worry about mappings like when using `pairwise`.
+
 
 ## Example
 
@@ -117,4 +149,5 @@ export function thisIsABadPipeline() {
 
 // => case 2. No Error thrown from tap  --> storeTheObject has the value generated in generateAnObjectToStore, not the undefined returned by validateThatTheObjectIsCool
 ```
+
 

--- a/docs/decorators/tap.md
+++ b/docs/decorators/tap.md
@@ -2,6 +2,63 @@
 
 Decorator that allows to transparently perform actions or side-effects, such as logging without loosing the previous step result. You can explore the source code [here](../../packages/bautajs-core/src/decorators/tap.ts).
 
+## tap decorator flow
+
+The `tap` decorator accepts any number of step functions and executes them sequentially.
+
+The `tap` decorator behaviour in a few words:
+
+If all goes well (no errors), at the end of the `tap` decorator execution, you will get as the result of this decorator the value returned by the previous step of this decorator (or in other words, the first element received by the first step function of the tap decorator).
+
+If there is an error, the error will be managed by the error handler attached to the decorator (be it the default one or a custom set through the `catchError` function). This can end in two cases: 
+- the error handler throws an error --> then this error is thrown by the `tap` decorator
+- the custom error handler does not throw any error --> then, as in the happy path case, the `tap` decorator returns as the result of this decorator step function the same value returned by the previous step to this decorator.
+
+### Short summary of `tap` behaviour
+
+At the end of `tap` decorator you will get:
+
+- an error that has interrupted the step function flow
+- the same value that was received by the first step function of the tap decorator if no error was triggered and thrown.
+
+## tap decorator usage
+
+There are two use cases where this decorator is useful:
+
+1. Synchronous Logging without need to return the previous value
+2. Asynchronous validation without need to drag the value between steps: this simplifies the pattern of usage because you do not need to worry about maintaining the value that you want to use *after* the validation or have to worry about mappings like when using `pairwise`.
+
+### Caution
+
+The tap decorator is very useful to proc side effects knowing that at the end you will get the origin value, but it can make readibility hard if you compose a lot of nested functions inside it. Our advice is to create steps accordingly and call them from the decorator to improve readibility.
+
+```javascript
+// do this
+export function thisIsAGoodPipeline() {
+  return pipe(
+   firstStepFunction,
+    secondStepFunction(),
+    tap(sideEffectValidationStepFunction()),
+    thirdStepFunction()
+  );
+}
+
+// avoid this
+export function thisIsABadPipeline() {
+  return pipe(
+   firstStepFunction,
+    secondStepFunction(),
+    tap(async(prev, ctx, bautajs) => {
+      // Code to access database
+      // Code to validate certain rules
+      // Code to decide whether the rules are meet or not and possibly throw an error
+    }),
+    thirdStepFunction()
+  );
+}
+
+```
+
 ## Example
 
 ### 1. Do a console log
@@ -11,19 +68,53 @@ Decorator that allows to transparently perform actions or side-effects, such as 
 
   const randomPreviousStep = step(() => 'I am so random!');
 
-   const pipeline = pipe(
-     randomPreviousStep,
-     tap((prev) => {
-       console.log(`some intermediate step. Prev is ${prev}`);
+  const sideEffectStep = (prev) => {
+    console.log(`some intermediate step. Prev is ${prev}`);
 
-       return 'this value will be lost';
-     }),
-     (prev) => {
-       // prev will be always the result of randomPreviousStep no matter what the tap function returns
-       console.log(prev);
-     }
-   );
+    return 'this value will be lost';
+  };
+
+  const pipeline = pipe(
+    randomPreviousStep,
+    tap(sideEffectStep),
+    (prev) => {
+      // prev will be the result of randomPreviousStep 
+      console.log(prev);
+    }
+  );
 
 // => 'some intermediate step. Prev is I am so random!'
 // => 'I am so random!'
 ```
+
+### 2. Asynchronous validation
+
+
+```javascript
+  const { tap, step, pipe } = require('@axa/bautajs-core');
+
+  const generateAnObjectToStore = step(() => 'I am so random!');
+
+  // This is asyncrhonous because this validation requires database or datasource access
+  const validateThatTheObjectIsCool = step(async (prev, ctx, bautajs) => {
+   
+    // database access
+
+    if (theObjectIsNotCool) {
+      throw new Error('Do not save uncool objects');
+    }
+  });
+
+
+
+  const pipeline = pipe(
+    generateAnObjectToStore,
+    tap(validateThatTheObjectIsCool),
+    storeTheObject
+  );
+
+// => case 1. Error throw inside tap --> we get the error and storeTheObject is never called
+
+// => case 2. No Error thrown from tap  --> storeTheObject has the value generated in generateAnObjectToStore, not the undefined returned by validateThatTheObjectIsCool
+```
+

--- a/packages/bautajs-core/src/decorators/pipeline.ts
+++ b/packages/bautajs-core/src/decorators/pipeline.ts
@@ -1,7 +1,7 @@
 import { BautaJSInstance, Context, GenericError, Pipeline } from '../types';
 import { isPromise } from '../utils/is-promise';
 
-function compose<T, R>(
+export function compose<T, R>(
   f1: Pipeline.StepFunction<T, R>,
   f2: Pipeline.StepFunction<T, R>
 ): Pipeline.StepFunction<T, R> {

--- a/packages/bautajs-core/src/decorators/tap.ts
+++ b/packages/bautajs-core/src/decorators/tap.ts
@@ -1,51 +1,227 @@
-import { Pipeline } from '../types';
+import { GenericError, Pipeline, Context, BautaJSInstance } from '../types';
 import { isPromise } from '../utils/is-promise';
+import { compose } from './pipeline';
+
+const defaultErrorHandler: Pipeline.CatchError<GenericError> = e => {
+  throw e;
+};
+
+export function tap<ValueType, ReturnType>(
+  f1: Pipeline.StepFunction<ValueType, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
+
+export function tap<ValueType, ResultValue1, ReturnType>(
+  f1: Pipeline.StepFunction<ValueType, ResultValue1>,
+  f2: Pipeline.StepFunction<ResultValue1, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
+
+export function tap<ValueType, ResultValue1, ResultValue2, ReturnType>(
+  f1: Pipeline.StepFunction<ValueType, ResultValue1>,
+  f2: Pipeline.StepFunction<ResultValue1, ResultValue2>,
+  f3: Pipeline.StepFunction<ResultValue2, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
+
+export function tap<ValueType, ResultValue1, ResultValue2, ResultValue3, ReturnType>(
+  f1: Pipeline.StepFunction<ValueType, ResultValue1>,
+  f2: Pipeline.StepFunction<ResultValue1, ResultValue2>,
+  f3: Pipeline.StepFunction<ResultValue2, ResultValue3>,
+  f4: Pipeline.StepFunction<ResultValue3, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
+
+export function tap<ValueType, ResultValue1, ResultValue2, ResultValue3, ResultValue4, ReturnType>(
+  f1: Pipeline.StepFunction<ValueType, ResultValue1>,
+  f2: Pipeline.StepFunction<ResultValue1, ResultValue2>,
+  f3: Pipeline.StepFunction<ResultValue2, ResultValue3>,
+  f4: Pipeline.StepFunction<ResultValue3, ResultValue4>,
+  f5: Pipeline.StepFunction<ResultValue4, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
+
+export function tap<
+  ValueType,
+  ResultValue1,
+  ResultValue2,
+  ResultValue3,
+  ResultValue4,
+  ResultValue5,
+  ReturnType
+>(
+  f1: Pipeline.StepFunction<ValueType, ResultValue1>,
+  f2: Pipeline.StepFunction<ResultValue1, ResultValue2>,
+  f3: Pipeline.StepFunction<ResultValue2, ResultValue3>,
+  f4: Pipeline.StepFunction<ResultValue3, ResultValue4>,
+  f5: Pipeline.StepFunction<ResultValue4, ResultValue5>,
+  f6: Pipeline.StepFunction<ResultValue5, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
+
+export function tap<
+  ValueType,
+  ResultValue1,
+  ResultValue2,
+  ResultValue3,
+  ResultValue4,
+  ResultValue5,
+  ResultValue6,
+  ReturnType
+>(
+  f1: Pipeline.StepFunction<ValueType, ResultValue1>,
+  f2: Pipeline.StepFunction<ResultValue1, ResultValue2>,
+  f3: Pipeline.StepFunction<ResultValue2, ResultValue3>,
+  f4: Pipeline.StepFunction<ResultValue3, ResultValue4>,
+  f5: Pipeline.StepFunction<ResultValue4, ResultValue5>,
+  f6: Pipeline.StepFunction<ResultValue5, ResultValue6>,
+  f7: Pipeline.StepFunction<ResultValue6, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
+
+export function tap<
+  ValueType,
+  ResultValue1,
+  ResultValue2,
+  ResultValue3,
+  ResultValue4,
+  ResultValue5,
+  ResultValue6,
+  ResultValue7,
+  ReturnType
+>(
+  f1: Pipeline.StepFunction<ValueType, ResultValue1>,
+  f2: Pipeline.StepFunction<ResultValue1, ResultValue2>,
+  f3: Pipeline.StepFunction<ResultValue2, ResultValue3>,
+  f4: Pipeline.StepFunction<ResultValue3, ResultValue4>,
+  f5: Pipeline.StepFunction<ResultValue4, ResultValue5>,
+  f6: Pipeline.StepFunction<ResultValue5, ResultValue6>,
+  f7: Pipeline.StepFunction<ResultValue6, ResultValue7>,
+  f8: Pipeline.StepFunction<ResultValue7, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
+
+export function tap<
+  ValueType,
+  ResultValue1,
+  ResultValue2,
+  ResultValue3,
+  ResultValue4,
+  ResultValue5,
+  ResultValue6,
+  ResultValue7,
+  ResultValue8,
+  ReturnType
+>(
+  f1: Pipeline.StepFunction<ValueType, ResultValue1>,
+  f2: Pipeline.StepFunction<ResultValue1, ResultValue2>,
+  f3: Pipeline.StepFunction<ResultValue2, ResultValue3>,
+  f4: Pipeline.StepFunction<ResultValue3, ResultValue4>,
+  f5: Pipeline.StepFunction<ResultValue4, ResultValue5>,
+  f6: Pipeline.StepFunction<ResultValue5, ResultValue6>,
+  f7: Pipeline.StepFunction<ResultValue6, ResultValue7>,
+  f8: Pipeline.StepFunction<ResultValue7, ResultValue8>,
+  f9: Pipeline.StepFunction<ResultValue8, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
+
+export function tap<
+  ValueType,
+  ResultValue1,
+  ResultValue2,
+  ResultValue3,
+  ResultValue4,
+  ResultValue5,
+  ResultValue6,
+  ResultValue7,
+  ResultValue8,
+  ResultValue9,
+  ReturnType
+>(
+  f1: Pipeline.StepFunction<ValueType, ResultValue1>,
+  f2: Pipeline.StepFunction<ResultValue1, ResultValue2>,
+  f3: Pipeline.StepFunction<ResultValue2, ResultValue3>,
+  f4: Pipeline.StepFunction<ResultValue3, ResultValue4>,
+  f5: Pipeline.StepFunction<ResultValue4, ResultValue5>,
+  f6: Pipeline.StepFunction<ResultValue5, ResultValue6>,
+  f7: Pipeline.StepFunction<ResultValue6, ResultValue7>,
+  f8: Pipeline.StepFunction<ResultValue7, ResultValue8>,
+  f9: Pipeline.StepFunction<ResultValue8, ResultValue9>,
+  f10: Pipeline.StepFunction<ResultValue9, ReturnType>
+): Pipeline.PipelineFunction<ValueType, ValueType>;
 
 /**
- * Decorator that allows to transparently perform actions or side-effects,
- * such as logging and return the previous step result.
+ * Decorator that allows to transparently perform actions or side-effects
+ * without losing the initial value that triggered them.
  *
- * Tap supports promises, but it will ignore any error thrown inside the tapped
- * promise and will wait for its execution just to ignore its value.
+ * All the step functions inside the tap pass the value as in a pipeline, but
+ * the result of the tap will be the value of the previous step.
  *
- * The step inside tap does not need to return anything, since if it returns anything,
- * it will be ignored anyways in favour of what was in the previous step.
+ * If an error occurs in the flow inside the tap, the flow is interrupted and goes
+ * to the error handler. This is to support asynchronous validations inside tap.
  *
- * @param {Pipeline.StepFunction<TIn, any>} stepFn - The step fn to execute
+ * It is important to note that tap does not parallelize any execution of the promises
+ * inside the decorator. The execution will have to finish before the next step.
+ *
+ * @param {stepFunctions: Array<Pipeline.StepFunction<T, R>>} stepFunctions - The step functions to execute
  * @returns {Pipeline.StepFunction<TIn, TIn>}
  *
  * @example
  *
- * const { tap, step, pipe } require('@axa/bautajs-core');
- *
- * const randomPreviousPipeline = step(() => 'I am so random!');
- *
- *  const pipeline = pipe(
- *    randomPreviousPipeline,
- *    tap((prev) => {
- *      console.log(`some intermediate step. Prev is "${prev}""`);
- *      // prints 'some intermediate step. Prev is "I am so random!"'
- *    }),
- *    tap(async (prev) => {
- *      await asyncProcess();
- *      //'whether asyncProcess resolves or rejects. Prev still will be "I am so random!"'
- *    }),
- *    (prev) => {
- *      console.log(prev);
- *      // prints 'I am so random!'
- *    }
- *  );
  *
  */
-export function tap<TIn>(
-  stepFn: Pipeline.StepFunction<TIn, TIn | void>
-): Pipeline.StepFunction<TIn, TIn | void> {
-  return (prev, ctx, bautajs) => {
-    const result = stepFn(prev, ctx, bautajs);
 
-    if (isPromise(result)) {
-      return (result as Promise<typeof result>).then(() => prev).catch(() => prev);
+export function tap<T, R>(
+  ...stepFunctions: Array<Pipeline.StepFunction<T, R>>
+): Pipeline.StepFunction<T, T> {
+  if (stepFunctions.length === 0 || !stepFunctions.every(fn => typeof fn === 'function')) {
+    throw new Error('All tap inputs must be a function or a promise.');
+  }
+
+  // Merge all step functions in one composited step function
+  const composition: Pipeline.StepFunction<T, R> = stepFunctions.reduce(
+    (acc: Pipeline.StepFunction<T, R> | undefined, fn) => {
+      // First iteration will always return the first function since the default value is undefined
+      if (!acc) {
+        return fn;
+      }
+      // eslint-disable-next-line no-param-reassign
+      acc = compose(acc, fn);
+
+      return acc;
+    },
+    undefined
+  ) as Pipeline.StepFunction<T, R>;
+
+  let errorHandler: Pipeline.CatchError<GenericError> = defaultErrorHandler;
+
+  function tapStepFunction(prev: T, ctx: Context, bautaJS: BautaJSInstance): PromiseLike<T> | T {
+    try {
+      const result = composition(prev, ctx, bautaJS);
+
+      if (isPromise(result)) {
+        // If it is a promise we either return the value of the previous step or we interrup the tap flow if an error has occurred
+        return (result as Promise<R>)
+          .then(() => prev) // tap behaviour is ignoring the results of its steps and return the result value of the previous step
+          .catch((e: GenericError) => {
+            // This pattern is to ensure that when the error handler throws we throw, and if the error handler *does not* throw,
+            // tap behaviour is maintained and we return the result value of the previous step
+            errorHandler(e, ctx, bautaJS) as any;
+            return prev;
+          });
+      }
+
+      return prev;
+    } catch (e: any) {
+      // This pattern is to ensure that when the error handler throws we throw, and if the error handler *does not* throw,
+      // tap behaviour is maintained and we return the result value of the previous step
+      errorHandler(e, ctx, bautaJS) as any;
+      return prev;
     }
-    return prev;
+  }
+
+  tapStepFunction.catchError = function catchError(
+    fn: Pipeline.CatchError<any>
+  ): Pipeline.StepFunction<T, T> {
+    // Even when through casting we can bypass the typescript type check we do not allow non-functions as this parameter
+    if (typeof fn !== 'function') {
+      throw new Error('Tap catchError function must be called with a function or a promise.');
+    }
+    errorHandler = fn;
+
+    return tapStepFunction;
   };
+
+  return tapStepFunction;
 }

--- a/packages/bautajs-core/src/decorators/tap.ts
+++ b/packages/bautajs-core/src/decorators/tap.ts
@@ -157,8 +157,6 @@ export function tap<
  * @param {stepFunctions: Array<Pipeline.StepFunction<T, R>>} stepFunctions - The step functions to execute
  * @returns {Pipeline.StepFunction<TIn, TIn>}
  *
- * @example
- *
  *
  */
 

--- a/packages/bautajs-core/src/decorators/test/tap.test.ts
+++ b/packages/bautajs-core/src/decorators/test/tap.test.ts
@@ -53,7 +53,7 @@ describe('tap decorator', () => {
     expect(log).toHaveBeenCalledWith('star wars');
   });
 
-  test('should ignore the error inside tap and return the previous step value', async () => {
+  test('should throw the error inside tap', async () => {
     const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
     const tappedPromise = async (name: string) => {
@@ -68,8 +68,141 @@ describe('tap decorator', () => {
       tap(step<{ name: string }, { name: string }>(async ({ name }) => tappedPromise(name)))
     );
 
+    await expect(() => pipeline({}, createContext({}), {} as BautaJSInstance)).rejects.toThrow(
+      new Error('We have an error: star wars')
+    );
+  });
+
+  test('should work if we mix multiple sync and async steps', async () => {
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    const log = jest.fn();
+    const tappedPromise = async (name: string) => {
+      await delay(100);
+      return log(name);
+    };
+
+    const tappedSyncFunction = (name: string) => `${name} is a great movie!`;
+
+    const getMovie = step(() => ({ name: 'star wars' }));
+
+    const pipeline = pipe(
+      getMovie,
+      tap(
+        step<{ name: string }, string>(({ name }) => name),
+        tappedSyncFunction,
+        tappedPromise
+      )
+    );
+
     await expect(pipeline({}, createContext({}), {} as BautaJSInstance)).resolves.toStrictEqual({
       name: 'star wars'
     });
+
+    expect(log).toHaveBeenCalledWith('star wars is a great movie!');
+  });
+
+  test('should work with a custom error handler', async () => {
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+    const getMovie = step(() => ({ name: 'star wars' }));
+
+    const log = jest.fn();
+
+    const asyncValidationPromise = async (name: string) => {
+      await delay(100);
+
+      if (name.length > 10) {
+        throw new Error(`Name ${name} is too long`);
+      }
+    };
+
+    const tappedSyncFunction = (name: string) => `${name} is a great movie!`;
+
+    const customErrorHandler = (e: Error) => {
+      log(e.message);
+      throw e;
+    };
+
+    const pipeline = pipe(
+      getMovie,
+      tap(
+        step<{ name: string }, string>(({ name }) => name),
+        tappedSyncFunction,
+        asyncValidationPromise
+      ).catchError(customErrorHandler)
+    );
+
+    await expect(pipeline({}, createContext({}), {} as BautaJSInstance)).rejects.toThrow(
+      new Error('Name star wars is a great movie! is too long')
+    );
+
+    expect(log).toHaveBeenCalledWith('Name star wars is a great movie! is too long');
+  });
+
+  test('should not allow an empty custom error handler', async () => {
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+    const getMovie = step(() => ({ name: 'star wars' }));
+
+    const asyncValidationPromise = async (name: string) => {
+      await delay(100);
+
+      if (name.length > 10) {
+        throw new Error(`Name ${name} is too long`);
+      }
+    };
+
+    const tappedSyncFunction = (name: string) => `${name} is a great movie!`;
+
+    const customErrorHandler = undefined;
+
+    expect(() =>
+      pipe(
+        getMovie,
+        tap(
+          step<{ name: string }, string>(({ name }) => name),
+          tappedSyncFunction,
+          asyncValidationPromise
+        ).catchError(customErrorHandler as any)
+      )
+    ).toThrow(new Error('Tap catchError function must be called with a function or a promise.'));
+  });
+
+  test('should return previous value when the custom error handler does not throw an error', async () => {
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+    const getMovie = step(() => ({ name: 'star wars' }));
+
+    const log = jest.fn();
+
+    const asyncValidationPromise = async (name: string) => {
+      await delay(100);
+
+      if (name.length > 10) {
+        throw new Error(`Name ${name} is too long`);
+      }
+    };
+
+    const tappedSyncFunction = (name: string) => `${name} is a great movie!`;
+
+    const customErrorHandler = (e: Error) => {
+      log(e.message);
+      return 'there is an error but we have decided to ignore it!';
+    };
+
+    const pipeline = pipe(
+      getMovie,
+      tap(
+        step<{ name: string }, string>(({ name }) => name),
+        tappedSyncFunction,
+        asyncValidationPromise
+      ).catchError(customErrorHandler)
+    );
+
+    await expect(pipeline({}, createContext({}), {} as BautaJSInstance)).resolves.toStrictEqual({
+      name: 'star wars'
+    });
+
+    expect(log).toHaveBeenCalledWith('Name star wars is a great movie! is too long');
   });
 });


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] I have added/updated documentation for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

This implements issue #138.

Basically implements tap in a consistent manner following the expected definition of the function tap function common in other languages/frameworks.

The detail of this definitioin is explained in the documentation of the pr itself, but a very brief defintion is this:

```
Given a set of step functions inside tap, the end result of tap is:

- either an exception if there was an exception while processing them
- the value received by the first step function inside tap decorator as its result
```

The end purpose of tap is allow side effects without losing the value used in the previous step function.
