### PR TITLE
fix(core): fix iif return types

### DIFF
--- a/packages/bautajs-core/package.json
+++ b/packages/bautajs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa/bautajs-core",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Bauta.js is an add-on for your Node.js applications such as Express.js or Fastify.",
   "main": "dist",
   "types": "dist",

--- a/packages/bautajs-core/src/decorators/iif.ts
+++ b/packages/bautajs-core/src/decorators/iif.ts
@@ -1,4 +1,15 @@
 import { BautaJSInstance, Context, Pipeline } from '../types';
+export function iif<TIn, TPipelineOut>(
+  condition: (prev: TIn, ctx: Context, bautajs: BautaJSInstance) => boolean,
+  pipeline: Pipeline.StepFunction<TIn, TPipelineOut>
+): Pipeline.StepFunction<TIn, TIn | TPipelineOut>;
+
+export function iif<TIn, TPipelineOut, TElsePipelineOut>(
+  condition: (prev: TIn, ctx: Context, bautajs: BautaJSInstance) => boolean,
+  pipeline: Pipeline.StepFunction<TIn, TPipelineOut>,
+  elsePipeline: Pipeline.StepFunction<TIn, TElsePipelineOut>
+): Pipeline.StepFunction<TIn, TPipelineOut | TElsePipelineOut>;
+
 /**
  * Decorator that allows to execute given pipeline conditionally. It accepts the condition step function and pipeline.
  * If the condition step function will be evaluated to truthy value the pipeline will be executed.


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] I have added/updated documentation for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
This pull request fix the return types of iif 
- no need to put a `never` third input type when we don't provide an else pipeline as the third parameter
before:
```js
iif<string, string, never>(
  (notEmptyString) => notEmptyString!==''
  () => 'the string is not empty'
)
```
now: 
```js
iif<string, string>(
  (notEmptyString) => notEmptyString!==''
  () => 'the string is not empty'
)
```
- when we use an else pipeline as the third parameter the returned type will never be mapped as the input first parameter on typescrit
having the following:
```js
iif<boolean, string, string>(
      (condition) => condition,
      () => 'if',
      () => 'else'
    ),
    (result) => {...}
```
before:
![Screenshot 2024-05-07 at 21 04 12](https://github.com/axa-group/bauta.js/assets/12146842/3bc2e205-3bea-47c6-8f14-2e246c47d883)
now:
![Screenshot 2024-05-07 at 21 04 51](https://github.com/axa-group/bauta.js/assets/12146842/1eecc433-8d33-40d3-8bac-73281055a8c4)
